### PR TITLE
DomeLNA: single-owner serial I/O thread, no @lock, off-axis sync check

### DIFF
--- a/docs/plans/dome-serial-io-thread.md
+++ b/docs/plans/dome-serial-io-thread.md
@@ -1,0 +1,175 @@
+# DomeLNA robustness: single-owner serial I/O thread + fewer `@lock`s
+
+Plan for lna40 PENDING_ISSUES.md issues 4 and 6, and the plugin-side half of
+issue 31. Written 2026-07-23.
+
+## Context
+
+Issues 4, 6 and 31 share one root: `DomeLNA` does synchronous serial I/O on
+whichever bus/control thread calls it, serialized only by the per-instance
+`@lock` monitor — and only partially:
+
+- **Issue 4**: `_command`/`_command_once`/`_reconnect` are *unlocked*, so the
+  control loop and a bus request raced on the port while `_reconnect()` swapped
+  `self._serial` under a concurrent reader → `os.read(None, …)` `TypeError`
+  killed a program. `_command` only catches `serial.SerialException`, so the
+  TypeError skipped the retry.
+- **Issue 31**: `@lock` (the instance monitor, chimera `metaobject.py`) is
+  acquired with **no timeout**, and `slew_to_az` holds it for the entire
+  multi-minute slew. Every later locked call (`close_slit`, the stale-cache
+  `_read_status` fallback behind `get_az`/`is_slewing`, the control loop's
+  `with self:`) parked a 64-pool bus worker forever; the whole server bus went
+  silent.
+- **Issue 6**: base `Dome.is_sync_with_tel()` (`@lock`, on-axis az comparison)
+  contradicts the lookup-table positioning → 259 false "could not be
+  synchronized" logs per night.
+
+Facts established from the code:
+
+- `@lock` is a marker (`core/lock.py`); `LockWrapperDispatcher` acquires the
+  single per-instance `Condition(RLock)`. Locked-vs-locked mutually exclude;
+  **unlocked methods never take the monitor**. The control loop `__main__`
+  runs `with self:` each cycle (`chimeraobject.py`), i.e. holds the monitor
+  during `control()`.
+- `DomeBase._process_queue` (chimera `instruments/dome.py`) has try/**finally**
+  only — an exception from `slew_to_az` propagates out of `control()` and
+  **kills the dome control loop thread silently** (a plausible contributor to
+  issue 5's "dome not tracking at night start").
+- `imagerequest.py` (`controllers/imageserver/imagerequest.py:118`) calls
+  `dome.sync_with_tel()` with no try/except → a dome hiccup aborts exposure +
+  focus run + program.
+- chimera-lna's working tree already holds uncommitted robustness work
+  (status-frame regex, status cache + `_read_status`, `_command`/`_reconnect`
+  split, simulator frame fix, tests) — land it first, as its own commit.
+
+Strategy: make **one thread the sole owner of the serial port** (commands
+travel over a queue as `(cmd, Future)`; every caller gets a bounded wait),
+then delete `@lock` from the plugin, keeping only a small explicit motion
+lock with a timeout. Model: `chimera-phd2guiding`'s `phd2_client.py`
+(pending-futures + owner thread), reduced to half-duplex single-consumer.
+
+## Changes
+
+### 0. chimera-lna: land the uncommitted work first
+
+Commit the current diff (domelna.py cache/reconnect/regex, simulator frame
+format, tests) as its own commit so the refactor diff stays clean.
+
+### 1. chimera core — blast-radius limiter (issue 4 step 1, ~8 lines)
+
+`src/chimera/controllers/imageserver/imagerequest.py:118-123`: wrap
+`dome.sync_with_tel()` / `dome.is_sync_with_tel()` in `try/except Exception` →
+log the existing `"Dome slit position could not be synchronized…"` line and
+continue the exposure.
+
+### 2. chimera core — control loop survives a failed slew (~5 lines)
+
+`src/chimera/instruments/dome.py` `_process_queue`: add `except Exception`
+around `self.slew_to_az(target)` → `log.warning(...)`, keep draining. The dome
+control loop must not die because one slew raised (it will also see the new
+"dome busy" error, which just retries next cycle via `_need_to_move`). No
+other core change — base-class `@lock`s stay.
+
+### 3. chimera-lna — serial I/O worker thread (single port owner)
+
+`domelna.py`:
+
+- `self._io_queue: queue.Queue[(str, Future) | None]`; daemon thread
+  `_io_loop` started in `__start__` before the startup reset sequence, joined
+  in `__stop__` via `None` sentinel.
+- Worker owns the port exclusively: opens it on startup, runs `_command_once`,
+  runs `_reconnect` on failure. `_create_serial`/`_close`/`_command_once`/
+  `_reconnect` become worker-only; nothing else may touch `self._serial` → the
+  fd-None race is structurally impossible.
+- Per-item handling: `_command_once(cmd)` with `except (serial.SerialException,
+  OSError, TypeError, ValueError)` → `_reconnect()` + one retry (the broader
+  except issue 4 asks for); result or exception set on the Future.
+- `_command(cmd)` (signature unchanged for all callers): enqueue +
+  `future.result(timeout=self._io_deadline)` where `_io_deadline ≈
+  2*serial_timeout + reconnect backoff (16 s) + margin` — every bus request is
+  now **bounded**; on timeout raise
+  `ChimeraException("dome serial I/O timed out")`.
+- On worker exit / stop: fail all pending futures (phd2_client
+  `_fail_pending` pattern).
+- Delete the direct `reset_input_buffer/reset_output_buffer` calls in
+  `_reset_dome` — `_command_once` already flushes per transaction.
+
+### 4. chimera-lna — remove `@lock`, add one bounded motion lock
+
+The queue now serializes all hardware access, so `@lock` only ever provided
+command *sequencing*. Final state — **zero `@lock` in domelna.py**:
+
+- `_read_status`, `switch_on`, `switch_off`: no lock at all (single queued
+  transaction; `_status_cache`/`_light_on` writes are atomic).
+  `get_az`/`is_slewing` stale-cache fallback now costs ≤ one queued STATUS
+  instead of parking behind a whole slew.
+- `slew_to_az`, `open_slit`, `close_slit`, `_init_dome`: guarded by a private
+  `self._motion_lock = threading.RLock()` via a small context helper that does
+  `acquire(timeout=self._motion_wait)` (~20 s) and raises
+  `ChimeraException("Dome busy…")` on failure — callers get a fast, explicit
+  "busy" instead of an unbounded monitor park (issue 31's plugin-side
+  direction). RLock because `slew_to_az → _get_tag → _init_dome` is
+  same-thread re-entrant.
+- Lock-order safety: base callers (`sync_with_tel`, `control()`'s
+  `with self:`) hold the monitor *then* take `_motion_lock`; `slew_to_az`'s
+  body calls no `@lock` method (verified: events, `get_az`, proxies are all
+  unlocked) → no monitor acquisition under `_motion_lock`, no inversion. Base
+  `sync_with_tel` still holds the monitor during a sync-slew, but it is now
+  bounded by `slew_timeout` (no I/O wedge can outlive `_io_deadline`) and no
+  status read waits on it.
+
+### 5. chimera-lna — override `is_sync_with_tel()` (issue 6, lock-free)
+
+Ask the question `slew_to_az` answers: get the tracking telescope via
+`_get_tracking_telescope()`; if available, compare current tag (cache-first
+via `_cached_status()`/`_read_status`) against
+`self._lookup.get_tag_altaz(alt, tel_az)` within `_dome_precision`; else fall
+back to `super().is_sync_with_tel()`. Unlocked → `imagerequest.py:119` no
+longer queues behind the monitor either. Kills the 259×/night false "could
+not be synchronized" noise while restoring the real mispositioning signal.
+
+## Files touched
+
+- `chimera/src/chimera/controllers/imageserver/imagerequest.py` (~8 lines)
+- `chimera/src/chimera/instruments/dome.py` (`_process_queue`, ~5 lines)
+- `chimera-lna/src/chimera_lna/instruments/domelna.py` (worker ~70 lines,
+  lock swap, override)
+- `chimera-lna/tests/chimera_lna/test_domelna.py` (new tests)
+
+Two pull requests: one for the core changes (1+2), one for the chimera-lna
+changes (0+3+4+5).
+
+## Verification (lna40 TEST_PLAN.md tiers)
+
+1. **Tier 1 — unit tests.** `uv run pytest` in chimera-lna (the simulator
+   already speaks the real controller frame format) and the chimera core
+   dome/imageserver suites. New tests against
+   `chimera_lna.simulators.dome` over `socket://`:
+   - stress: one thread slews while N threads hammer `get_az`/`is_slewing`/
+     `is_slit_open`/`is_sync_with_tel` — assert no exception, no corrupted
+     frame, all answers < ~2 s;
+   - kill/restart the simulator socket mid-slew — assert reconnect + retry,
+     and that a dead port surfaces as a clean `ChimeraException` within
+     `_io_deadline`, never a hang;
+   - concurrent `slew_to_az` + `open_slit` — second caller gets "Dome busy"
+     within `_motion_wait`;
+   - a raising `slew_to_az` on the control path leaves the control loop alive
+     (dome still tracking next cycle).
+2. **Tier 2 — fast-forward integration.** `lna40/scripts/fastforward_ci.sh`
+   with the dome block switched from `FakeDome` to `DomeLNA` +
+   `chimera_lna.simulators.dome` over `socket://` so a whole fast night
+   drives the real driver: track/sync every block, slit open/close, lamp for
+   flats. Pass criterion: an empty error scan.
+3. **Tier 3 — digital twin on "server".** Soak for at least a night with the
+   twin config, watching `docker compose logs` for dome tracebacks/ERRORs and
+   confirming the "could not be synchronized" noise is gone.
+4. **Tier 4 — opd-40.** Deploy over VPN; restart only with operator
+   confirmation, then one real night.
+
+## Explicitly out of scope
+
+- Core `@lock`/`_handle_request` timeout work (issue 31's server-side bound) —
+  separate effort.
+- Issue 5 log forensics (though change 2 removes one silent-death mode that
+  could cause it).
+- `abort_slew` (still `NotImplementedError`), slit-status-from-STATUS FIXME.

--- a/src/chimera_lna/instruments/domelna.py
+++ b/src/chimera_lna/instruments/domelna.py
@@ -4,14 +4,16 @@
 
 import math
 import os
+import queue
 import re
 import threading
 import time
+from concurrent.futures import Future
+from contextlib import contextmanager
 
 import serial
 from chimera.core import SYSTEM_CONFIG_DIRECTORY
 from chimera.core.exceptions import ChimeraException
-from chimera.core.lock import lock
 from chimera.instruments.dome import DomeBase
 from chimera.instruments.lamp import LampBase
 from chimera.interfaces.dome import (
@@ -48,6 +50,7 @@ class DomeLNA(DomeBase, LampBase):
         "serial_timeout": 10.0,  # seconds
         "retry_delay": 2.0,  # seconds between command retries
         "poll_interval": 1.0,  # seconds between dome status polls
+        "motion_wait": 20.0,  # seconds to wait for a running motion command
     }
 
     def __init__(self):
@@ -59,8 +62,19 @@ class DomeLNA(DomeBase, LampBase):
         # self["park_position"] = 108
         self._park_tag = 900
 
-        # Serial port
+        # Serial port: owned exclusively by the I/O worker thread. Callers
+        # submit commands through _io_queue and wait on a Future, so exactly
+        # one thread ever touches the port (no reconnect-under-reader races).
         self._serial = None
+        self._io_queue = queue.Queue()
+        self._io_thread = None
+        self._reconnect_delays = (1, 5, 10)
+
+        # Motion commands exclude each other with a bounded wait: a caller
+        # that cannot start within motion_wait gets "Dome busy" instead of
+        # parking a bus worker for a whole slew. RLock: slew_to_az can reach
+        # _init_dome on the same thread through _get_tag.
+        self._motion_lock = threading.RLock()
 
         # Few parameters...
         self._init_az = 108
@@ -73,11 +87,10 @@ class DomeLNA(DomeBase, LampBase):
         self._status_tries = 5  # STATUS polls before giving up on a valid frame
 
         # Last valid STATUS frame: (tag, busy, monotonic timestamp).
-        # get_az()/is_slewing() answer from this instead of competing for
-        # the serial port: a slew in progress polls STATUS every
-        # poll_interval while holding the monitor, so during motion the
-        # cache is always fresher than the TTL and callers get an instant
-        # answer instead of blocking for the whole slew.
+        # get_az()/is_slewing() answer from this instead of queueing their
+        # own STATUS command: a slew in progress polls STATUS every
+        # poll_interval, so during motion the cache is always fresher than
+        # the TTL and callers get an instant answer.
         self._status_cache = None
         self._status_cache_ttl = 2.0  # seconds; > poll_interval
 
@@ -94,35 +107,65 @@ class DomeLNA(DomeBase, LampBase):
             self.log.warning(f"Could not create dome debug file ({str(e)})")
 
     def __start__(self):
-        self._open()
+        self._io_thread = threading.Thread(
+            target=self._io_loop, name="DomeLNA-serial", daemon=True
+        )
+        self._io_thread.start()
+        # On start, reset the dome to the park tag, read the position back
+        # and check the controller answers idle.
+        self._reset_dome(reset_tag=self._park_tag)
+        self.get_az()
+        self._check_idle()
         return super().__start__()
 
     def __stop__(self):
         super().__stop__()
-        self._close()
+        self._io_queue.put(None)
+        if self._io_thread is not None:
+            self._io_thread.join(timeout=self["serial_timeout"] + 5)
 
     def _create_serial(self):
         return serial.serial_for_url(
             self["device"], baudrate=9600, timeout=self["serial_timeout"]
         )
 
-    def _open(self):
-        # Open the serial Port.
-        self._serial = self._create_serial()
-        # On start, reset the dome.
-        self._reset_dome(reset_tag=self._park_tag)
-        # Get the dome azimuth just to move it to the init position if needed.
-        self.get_az()
-        # Check if connection is okay.
-        self._check_idle()
-
     def _close(self):
         if self._serial is not None and self._serial.is_open:
             self._serial.close()
 
+    def _io_loop(self):
+        """
+        Sole owner of the serial port: opens it, runs every command
+        transaction and reconnects on failure. Exits on the None sentinel,
+        closing the port and failing whatever raced in after it.
+        """
+        try:
+            self._serial = self._create_serial()
+        except Exception as e:
+            # keep serving: the first command will go through _reconnect()
+            self.log.warning(f"Could not open dome serial port ({e}).")
+        while True:
+            item = self._io_queue.get()
+            if item is None:
+                break
+            cmd, future = item
+            try:
+                future.set_result(self._transact(cmd))
+            except Exception as e:
+                future.set_exception(e)
+        self._close()
+        self._fail_pending(ChimeraException("Dome I/O worker stopped."))
+
+    def _fail_pending(self, error):
+        while True:
+            try:
+                item = self._io_queue.get_nowait()
+            except queue.Empty:
+                return
+            if item is not None:
+                item[1].set_exception(error)
+
     def _reset_dome(self, reset_tag=None):
-        self._serial.reset_input_buffer()
-        self._serial.reset_output_buffer()
         ack = ""
         # Reset the queue.
         for _ in range(self._restart_tries):
@@ -200,9 +243,10 @@ class DomeLNA(DomeBase, LampBase):
         Reopen the serial port after a fatal serial error (e.g. a USB
         re-enumeration makes reads return EOF and pyserial raise
         SerialException). Does not reset/move the dome, only the port.
+        Runs on the I/O worker thread only.
         """
         self._close()
-        for delay in (1, 5, 10):
+        for delay in self._reconnect_delays:
             try:
                 self._serial = self._create_serial()
                 self.log.info("Reconnected to the dome serial port.")
@@ -213,9 +257,31 @@ class DomeLNA(DomeBase, LampBase):
         self._serial = self._create_serial()
 
     def _command(self, cmd):
+        """
+        Queue cmd to the I/O worker and wait for the reply. The wait is
+        bounded (one transaction plus a full reconnect cycle), so a sick
+        port surfaces as an exception, never as an indefinitely parked
+        bus worker.
+        """
+        future = Future()
+        self._io_queue.put((cmd, future))
+        deadline = 2 * self["serial_timeout"] + sum(self._reconnect_delays) + 5
         try:
+            return future.result(timeout=deadline)
+        except TimeoutError:
+            raise ChimeraException(
+                f"Dome serial I/O timed out after {deadline:.0f}s on '{cmd}'"
+            ) from None
+
+    def _transact(self, cmd):
+        """One command transaction on the I/O worker thread."""
+        try:
+            if self._serial is None:
+                raise serial.SerialException("serial port is not open")
             return self._command_once(cmd)
-        except serial.SerialException as e:
+        except (serial.SerialException, OSError, TypeError, ValueError) as e:
+            # a half-open port (USB gone mid-read) fails inside pyserial in
+            # more ways than SerialException alone
             self.log.warning(f"Serial error sending '{cmd}' ({e}). Reconnecting...")
             self._debug(f"[error] '{cmd}' - {e}")
             self._reconnect()
@@ -241,14 +307,29 @@ class DomeLNA(DomeBase, LampBase):
         self._debug("[read ] '{}'".format(repr(ack).replace("'", "")))
         return ack.replace("\r", "")
 
-    @lock
+    @contextmanager
+    def _motion(self):
+        """
+        Serialize motion commands (slew, slit, init) with a bounded wait:
+        the I/O queue already serializes port access, this only keeps whole
+        motion sequences from interleaving.
+        """
+        if not self._motion_lock.acquire(timeout=self["motion_wait"]):
+            raise ChimeraException(
+                "Dome busy: another motion command is running "
+                f"(waited {self['motion_wait']:.0f}s)."
+            )
+        try:
+            yield
+        finally:
+            self._motion_lock.release()
+
     def switch_on(self):
         ret = "ACK" in self._command("MEADE FLAT_WEAK LIGAR")
         if ret:
             self._light_on = True
         return ret
 
-    @lock
     def switch_off(self):
         ret = "ACK" in self._command("MEADE FLAT_WEAK DESLIGAR")
         if ret:
@@ -262,23 +343,23 @@ class DomeLNA(DomeBase, LampBase):
         # FIXME: bool(self._command("MEADE PROG STATUS")[19])
         return self._slit_open
 
-    @lock
     def open_slit(self):
-        self.log.debug("Opening dome slit.")
-        ack = "ACK" in self._command("MEADE TRAPEIRA ABRIR")
-        if ack:
-            self._slit_open = True
-            self.slit_opened(self.get_az())
-        return ack
+        with self._motion():
+            self.log.debug("Opening dome slit.")
+            ack = "ACK" in self._command("MEADE TRAPEIRA ABRIR")
+            if ack:
+                self._slit_open = True
+                self.slit_opened(self.get_az())
+            return ack
 
-    @lock
     def close_slit(self):
-        self.log.debug("Closing dome slit.")
-        ack = "ACK" in self._command("MEADE TRAPEIRA FECHAR")
-        if ack:
-            self._slit_open = False
-            self.slit_closed(self.get_az())
-        return ack
+        with self._motion():
+            self.log.debug("Closing dome slit.")
+            ack = "ACK" in self._command("MEADE TRAPEIRA FECHAR")
+            if ack:
+                self._slit_open = False
+                self.slit_closed(self.get_az())
+            return ack
 
     def _get_tag(self):
         for _ in range(self._status_tries):
@@ -317,25 +398,24 @@ class DomeLNA(DomeBase, LampBase):
             return cached[0], cached[1]
         return None
 
-    @lock
     def _read_status(self):
-        """Serial STATUS read behind the monitor. Single transaction:
-        _get_tag() refreshes the cache with the busy bit of the same frame."""
+        """Fresh STATUS read through the I/O queue: _get_tag() refreshes
+        the cache with the busy bit of the same frame."""
         tag = self._get_tag()
         return tag, self._status_cache[1]
 
     def get_az(self, tag=None):
-        # cache first: a locked read would block behind a slew in progress
-        # even though the slew itself refreshes the cache every second
+        # cache first: a slew in progress refreshes the cache every
+        # poll_interval, so callers get an instant answer during motion
         if tag is None:
             cached = self._cached_status()
             tag = cached[0] if cached else self._read_status()[0]
         return float(self._tag_to_az(tag))
 
-    @lock
     def _init_dome(self):
-        self._debug("Initializing dome...")
-        self._reset_dome(reset_tag=self._park_tag)
+        with self._motion():
+            self._debug("Initializing dome...")
+            self._reset_dome(reset_tag=self._park_tag)
 
     def _get_tracking_telescope(self):
         """
@@ -359,8 +439,11 @@ class DomeLNA(DomeBase, LampBase):
             self.log.debug(f"Telescope not available ({e}). Using geometric model.")
             return None
 
-    @lock
     def slew_to_az(self, az):
+        with self._motion():
+            return self._do_slew_to_az(az)
+
+    def _do_slew_to_az(self, az):
         if az > 360:
             raise InvalidDomePositionException(
                 f"Cannot slew to {az}. Outside azimuth limits."
@@ -479,14 +562,26 @@ class DomeLNA(DomeBase, LampBase):
         raise NotImplementedError()
 
     def is_slewing(self):
-        # cache first, for the same reason as get_az() — and the locked
-        # fallback also stops this from hitting the serial port while the
-        # slew polling loop is mid-read (unlocked, that corrupts both frames
-        # and costs a serial_timeout each)
+        # cache first, for the same reason as get_az()
         cached = self._cached_status()
         if cached is not None:
             return cached[1]
         return self._read_status()[1]
+
+    def is_sync_with_tel(self):
+        # The LNA telescope is off the dome axis: dome az != telescope az by
+        # design (median 24 deg), so the base on-axis |tel_az - dome_az|
+        # check reports "not synced" for almost every correct pointing. Ask
+        # the question slew_to_az answers instead: are we on the tag the
+        # lookup table wants for the telescope's alt/az?
+        telescope = self._get_tracking_telescope()
+        if telescope is None:
+            return super().is_sync_with_tel()
+        alt, telescope_az = telescope.get_position_alt_az()
+        dome_tag = self._lookup.get_tag_altaz(alt, telescope_az)
+        cached = self._cached_status()
+        tag = cached[0] if cached else self._read_status()[0]
+        return self._tag_distance(tag, dome_tag) <= self._dome_precision
 
     def get_metadata(self, request):
         # Check first if there is metadata from an metadata override method.

--- a/src/chimera_lna/instruments/domelna.py
+++ b/src/chimera_lna/instruments/domelna.py
@@ -4,6 +4,7 @@
 
 import math
 import os
+import re
 import threading
 import time
 
@@ -69,6 +70,16 @@ class DomeLNA(DomeBase, LampBase):
         self._dome_precision = 2  # Number of tags = +/- 4 degrees
         self._restart_precision = 4  # Number of tags = +/- 8 degrees.
         self._restart_tries = 3
+        self._status_tries = 5  # STATUS polls before giving up on a valid frame
+
+        # Last valid STATUS frame: (tag, busy, monotonic timestamp).
+        # get_az()/is_slewing() answer from this instead of competing for
+        # the serial port: a slew in progress polls STATUS every
+        # poll_interval while holding the monitor, so during motion the
+        # cache is always fresher than the TTL and callers get an instant
+        # answer instead of blocking for the whole slew.
+        self._status_cache = None
+        self._status_cache_ttl = 2.0  # seconds; > poll_interval
 
         # Load LookUp table
         self._lookup = DomeLookupTable()
@@ -142,14 +153,37 @@ class DomeLNA(DomeBase, LampBase):
                 return
             time.sleep(self["poll_interval"])
 
-    def _check_idle(self):
+    # A well-formed STATUS frame: 8 spaces, 3-digit tag, space, '*' and 16
+    # status bits. Motor EMI corrupts single bytes while the dome moves, so
+    # any frame that does not match exactly is discarded instead of trusted.
+    _status_re = re.compile(r"^ {8}(\d{3}) \*([01]{16})$")
+    _status_blank_re = re.compile(r"^ {11} \*[01]{16}$")
+
+    def _get_status(self):
+        """
+        Send MEADE PROG STATUS and parse the reply.
+
+        Returns (tag, busy) for a well-formed frame, "blank" for a valid
+        frame with an empty tag field (dome not initialized), or None for a
+        corrupted/unparseable reply.
+        """
         ack = self._command("MEADE PROG STATUS")
-        if ack.startswith("NAK"):
-            self.log.debug("Got a NAK on status.")
+        m = self._status_re.match(ack)
+        if m and 801 <= int(m.group(1)) <= 982:
+            tag, busy = int(m.group(1)), m.group(2)[3] == "1"
+            self._status_cache = (tag, busy, time.monotonic())
+            return tag, busy
+        if self._status_blank_re.match(ack):
+            return "blank"
+        self.log.debug(f"Discarding invalid dome status frame ({ack!r}).")
+        return None
+
+    def _check_idle(self):
+        status = self._get_status()
+        if not isinstance(status, tuple):
+            # NAK, blank or corrupted frame: report busy, callers keep polling
             return False
-        if len(ack) < 17:  # Sometimes ack is garbage. So, return that dome is busy.
-            return False
-        return ack[16] != "1"  # if '1', system busy
+        return not status[1]
 
     def _debug(self, msg):
         if self._debug_log:
@@ -161,7 +195,33 @@ class DomeLNA(DomeBase, LampBase):
             )
             self._debug_log.flush()
 
+    def _reconnect(self):
+        """
+        Reopen the serial port after a fatal serial error (e.g. a USB
+        re-enumeration makes reads return EOF and pyserial raise
+        SerialException). Does not reset/move the dome, only the port.
+        """
+        self._close()
+        for delay in (1, 5, 10):
+            try:
+                self._serial = self._create_serial()
+                self.log.info("Reconnected to the dome serial port.")
+                return
+            except serial.SerialException as e:
+                self.log.warning(f"Dome reconnect failed ({e}). Retrying in {delay}s.")
+                time.sleep(delay)
+        self._serial = self._create_serial()
+
     def _command(self, cmd):
+        try:
+            return self._command_once(cmd)
+        except serial.SerialException as e:
+            self.log.warning(f"Serial error sending '{cmd}' ({e}). Reconnecting...")
+            self._debug(f"[error] '{cmd}' - {e}")
+            self._reconnect()
+            return self._command_once(cmd)
+
+    def _command_once(self, cmd):
         self._serial.reset_output_buffer()
         self._serial.reset_input_buffer()
         self._debug(f"[write] '{cmd}'")
@@ -221,16 +281,20 @@ class DomeLNA(DomeBase, LampBase):
         return ack
 
     def _get_tag(self):
-        ack = self._command("MEADE PROG STATUS")[8:11]
-        if ack == "   ":
-            self.log.info("Initializing dome...")
-            self._init_dome()
-            time.sleep(self["poll_interval"])
-            self.log.info("Dome initialized.")
-            ack = float(self._command("MEADE PROG STATUS")[8:11])
-        else:
-            ack = float(ack)
-        return ack
+        for _ in range(self._status_tries):
+            status = self._get_status()
+            if isinstance(status, tuple):
+                return float(status[0])
+            if status == "blank":
+                self.log.info("Initializing dome...")
+                self._init_dome()
+                time.sleep(self["poll_interval"])
+                self.log.info("Dome initialized.")
+                continue
+            time.sleep(self["retry_delay"])
+        raise ChimeraException(
+            f"Could not read a valid dome position after {self._status_tries} tries"
+        )
 
     @staticmethod
     def _tag_to_az(tag):
@@ -246,10 +310,26 @@ class DomeLNA(DomeBase, LampBase):
         else:
             return int(math.ceil(az / 2.0 + 846))
 
+    def _cached_status(self):
+        """Return the last (tag, busy) if fresher than the TTL, else None."""
+        cached = self._status_cache
+        if cached and (time.monotonic() - cached[2]) <= self._status_cache_ttl:
+            return cached[0], cached[1]
+        return None
+
     @lock
+    def _read_status(self):
+        """Serial STATUS read behind the monitor. Single transaction:
+        _get_tag() refreshes the cache with the busy bit of the same frame."""
+        tag = self._get_tag()
+        return tag, self._status_cache[1]
+
     def get_az(self, tag=None):
+        # cache first: a locked read would block behind a slew in progress
+        # even though the slew itself refreshes the cache every second
         if tag is None:
-            tag = self._get_tag()
+            cached = self._cached_status()
+            tag = cached[0] if cached else self._read_status()[0]
         return float(self._tag_to_az(tag))
 
     @lock
@@ -292,11 +372,22 @@ class DomeLNA(DomeBase, LampBase):
         if telescope is not None:
             alt, telescope_az = telescope.get_position_alt_az()
             dome_tag = self._lookup.get_tag_altaz(alt, telescope_az)
-            # Don't move if we are on the right position.
-            if abs(dome_tag - self._get_tag()) <= self._dome_precision:
-                return True
         else:
             dome_tag = self._az_to_tag(az)
+
+        # Don't move (nor disturb the controller) if already on position.
+        if self._tag_distance(dome_tag, self._get_tag()) <= self._dome_precision:
+            return True
+
+        # MOVER is NAKed while the controller is busy: if a previous command
+        # left the dome moving, wait for it instead of triggering a reset.
+        t0 = time.time()
+        while not self._check_idle():
+            if time.time() - t0 > self["slew_timeout"]:
+                self.log.warning("Dome busy for too long before slew. Resetting...")
+                self._reset_dome()
+                break
+            time.sleep(self["poll_interval"])
 
         # Run dome move command.
         # Works on the first try?
@@ -328,7 +419,7 @@ class DomeLNA(DomeBase, LampBase):
         for i_retry in range(self._restart_tries):
             t0 = time.time()
             tag_now = self._get_tag()
-            if abs(tag_now - dome_tag) < self._restart_precision:
+            if self._tag_distance(tag_now, dome_tag) < self._restart_precision:
                 # If position is wrong for less than restart_precision, just confirm.
                 self.slew_complete(self.get_az(tag_now), DomeStatus.OK)
                 return True
@@ -353,6 +444,22 @@ class DomeLNA(DomeBase, LampBase):
                     break
                 time.sleep(self["poll_interval"])
 
+        self.slew_complete(self.get_az(), DomeStatus.ABORTED)
+        raise DomeSlewTimeoutException(
+            f"Dome did not reach tag {dome_tag} after "
+            f"{self._restart_tries} restarts (currently at {self._get_tag():.0f})"
+        )
+
+    @staticmethod
+    def _tag_distance(tag_a, tag_b):
+        """
+        Distance between two tags in tags, accounting for the wrap-around
+        (the 182-tag range 801-982 covers a full turn: 981/982 overlap
+        801/802, so one revolution is 180 tags).
+        """
+        distance = abs(tag_a - tag_b) % 180
+        return min(distance, 180 - distance)
+
     @staticmethod
     def _recovery_tag(dome_tag):
         """
@@ -372,7 +479,14 @@ class DomeLNA(DomeBase, LampBase):
         raise NotImplementedError()
 
     def is_slewing(self):
-        return not self._check_idle()
+        # cache first, for the same reason as get_az() — and the locked
+        # fallback also stops this from hitting the serial port while the
+        # slew polling loop is mid-read (unlocked, that corrupts both frames
+        # and costs a serial_timeout each)
+        cached = self._cached_status()
+        if cached is not None:
+            return cached[1]
+        return self._read_status()[1]
 
     def get_metadata(self, request):
         # Check first if there is metadata from an metadata override method.

--- a/src/chimera_lna/simulators/dome.py
+++ b/src/chimera_lna/simulators/dome.py
@@ -60,8 +60,8 @@ class DomeSimulator:
     move command followed by busy status polls until the position is reached.
 
     Supported commands:
-        MEADE PROG STATUS         -> "ACK STATnnn bsy=b00" (tag at [8:11],
-                                     busy flag at [16])
+        MEADE PROG STATUS         -> "        nnn *bbbbbbbbbbbbbbbb" (tag at
+                                     [8:11], 16 status bits, busy at [16])
         MEADE PROG PARAR          -> stop movement
         MEADE PROG RESET          -> restart controller
         MEADE DOMO MOVER = NNN    -> move to tag NNN (801..982)
@@ -155,10 +155,12 @@ class DomeSimulator:
         if command == "MEADE PROG STATUS":
             with self._lock:
                 self._update_position()
-                busy = "1" if self._move_started is not None else "0"
+                busy = self._move_started is not None
                 tag = int(round(self._position))
-            # DomeLNA expects the tag at chars [8:11] and the busy flag at [16]
-            return f"ACK STAT{tag:03d} bsy={busy}00"
+            # Real controller frame: 8 spaces, 3-digit tag, ' *' and 16 status
+            # bits. DomeLNA validates this layout strictly (busy bit at [16]).
+            bits = f"00{int(not busy)}{int(busy)}" + "0" * 12
+            return f"        {tag:03d} *{bits}"
 
         elif command == "MEADE PROG PARAR":
             with self._lock:

--- a/src/chimera_lna/simulators/dome.py
+++ b/src/chimera_lna/simulators/dome.py
@@ -20,6 +20,7 @@ Run it standalone with:
 
 import argparse
 import math
+import socket
 import socketserver
 import threading
 import time
@@ -31,19 +32,23 @@ MAX_TAG = 982
 class _DomeRequestHandler(socketserver.BaseRequestHandler):
     def handle(self):
         simulator = self.server.simulator
+        simulator._connections.add(self.request)
         buffer = b""
-        while True:
-            try:
-                data = self.request.recv(1024)
-            except ConnectionError:
-                break
-            if not data:
-                break
-            buffer += data
-            while b"\r" in buffer:
-                line, _, buffer = buffer.partition(b"\r")
-                response = simulator.process_command(line.decode().strip())
-                self.request.sendall(f"{response}\r".encode())
+        try:
+            while True:
+                try:
+                    data = self.request.recv(1024)
+                except (ConnectionError, OSError):
+                    break
+                if not data:
+                    break
+                buffer += data
+                while b"\r" in buffer:
+                    line, _, buffer = buffer.partition(b"\r")
+                    response = simulator.process_command(line.decode().strip())
+                    self.request.sendall(f"{response}\r".encode())
+        finally:
+            simulator._connections.discard(self.request)
 
 
 class _DomeServer(socketserver.ThreadingTCPServer):
@@ -87,6 +92,7 @@ class DomeSimulator:
 
         self._server = None
         self._thread = None
+        self._connections = set()
 
     # lifecycle
 
@@ -106,6 +112,15 @@ class DomeSimulator:
             self._thread.join()
             self._server = None
             self._thread = None
+
+    def drop_connections(self):
+        """Sever every live client connection (simulates a serial/USB drop);
+        the server keeps listening, so clients can reconnect."""
+        for conn in list(self._connections):
+            try:
+                conn.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
 
     def __enter__(self):
         return self.start()

--- a/tests/chimera_lna/test_domelna.py
+++ b/tests/chimera_lna/test_domelna.py
@@ -8,9 +8,11 @@ as if it were the real hardware.
 
 import re
 import socket
+import threading
 import time
 
 import pytest
+from chimera.instruments.faketelescope import FakeTelescope
 
 from chimera_lna.instruments.domelna import DomeLNA
 from chimera_lna.simulators.dome import DomeSimulator
@@ -186,6 +188,26 @@ class TestDomeLNALifecycle:
         assert metadata["DOME_SLT"] == "Closed"
         assert "DOME_AZ" in metadata
 
+    def test_is_sync_with_tel_uses_lookup_table(self, simulator, manager):
+        # off-axis dome: dome az != telescope az by design, so the base
+        # on-axis check would report "not synced" for a correctly positioned
+        # dome. The override must agree with where slew_to_az goes.
+        telescope = manager.add_class(FakeTelescope, "fake")
+        telescope.start_tracking()
+        dome = manager.add_class(
+            DomeLNA,
+            "sync",
+            config={
+                "device": simulator.device,
+                "telescope": "/FakeTelescope/fake",
+                **FAST_TIMINGS,
+            },
+        )
+        # with the telescope tracking, the az argument is overridden by the
+        # lookup-table tag for the telescope's alt/az
+        dome.slew_to_az(0.0)
+        assert dome.is_sync_with_tel()
+
     def test_shutdown_closes_connection(self, simulator, manager):
         manager.add_class(
             DomeLNA, "stop", config={"device": simulator.device, **FAST_TIMINGS}
@@ -194,3 +216,121 @@ class TestDomeLNALifecycle:
         # after __stop__ the driver must have disconnected: the simulator
         # still answers new connections
         assert raw_command(simulator, "MEADE PROG STATUS")[8:11].isdigit()
+
+
+class _FastReconnectDome(DomeLNA):
+    """DomeLNA with sub-second reconnect backoff, for failure-path tests."""
+
+    def __init__(self):
+        super().__init__()
+        self._reconnect_delays = (0.05, 0.1)
+
+
+def _proxy(manager, path):
+    """A fresh per-thread proxy (get_proxy needs a full bus URL)."""
+    return manager.get_proxy(
+        f"tcp://{manager.get_hostname()}:{manager.get_port()}{path}"
+    )
+
+
+class TestDomeLNAConcurrency:
+    """The serial port is owned by one I/O thread: status queries must keep
+    answering during a slew, motion commands must exclude each other with a
+    bounded 'busy' error, and a broken connection must recover or surface as
+    a clean exception - never wedge a caller."""
+
+    def test_status_reads_answer_during_slew(self, manager):
+        with DomeSimulator(initial_tag=900, tags_per_second=30) as simulator:
+            manager.add_class(
+                DomeLNA, "lna", config={"device": simulator.device, **FAST_TIMINGS}
+            )
+            errors, latencies = [], []
+
+            def slew():
+                try:
+                    _proxy(manager, "/DomeLNA/lna").slew_to_az(180.0)
+                except Exception as e:
+                    errors.append(e)
+
+            def hammer():
+                proxy = _proxy(manager, "/DomeLNA/lna")
+                t_end = time.time() + 1.0
+                while time.time() < t_end:
+                    t0 = time.time()
+                    try:
+                        proxy.get_az()
+                        proxy.is_slewing()
+                        proxy.is_slit_open()
+                    except Exception as e:
+                        errors.append(e)
+                        return
+                    latencies.append(time.time() - t0)
+
+            slewer = threading.Thread(target=slew)
+            slewer.start()
+            t0 = time.time()
+            while not simulator.is_moving and time.time() - t0 < 5:
+                time.sleep(0.01)
+            assert simulator.is_moving
+
+            hammerers = [threading.Thread(target=hammer) for _ in range(3)]
+            for thread in hammerers:
+                thread.start()
+            for thread in hammerers:
+                thread.join()
+            slewer.join()
+
+            assert errors == []
+            assert latencies and max(latencies) < 2.0
+            assert simulator.current_tag == DomeLNA._az_to_tag(180.0)
+
+    def test_concurrent_motion_gets_busy_error(self, manager):
+        with DomeSimulator(initial_tag=900, tags_per_second=20) as simulator:
+            dome = manager.add_class(
+                DomeLNA,
+                "lna",
+                config={
+                    "device": simulator.device,
+                    "motion_wait": 0.3,
+                    **FAST_TIMINGS,
+                },
+            )
+            slewer = threading.Thread(
+                target=lambda: _proxy(manager, "/DomeLNA/lna").slew_to_az(180.0)
+            )
+            slewer.start()
+            t0 = time.time()
+            while not simulator.is_moving and time.time() - t0 < 5:
+                time.sleep(0.01)
+            assert simulator.is_moving
+
+            with pytest.raises(Exception, match="Dome busy|ChimeraException"):
+                dome.open_slit()
+            slewer.join()
+
+    def test_reconnects_after_connection_drop(self, dome, simulator):
+        simulator.drop_connections()
+        # next command hits the dead socket, reconnects (the server is
+        # still listening) and retries transparently
+        dome.slew_to_az(180.0)
+        assert simulator.current_tag == DomeLNA._az_to_tag(180.0)
+
+    def test_dead_port_raises_quickly_instead_of_hanging(self, manager):
+        simulator = DomeSimulator(initial_tag=900, tags_per_second=500.0).start()
+        dome = manager.add_class(
+            _FastReconnectDome,
+            "lna",
+            config={
+                "device": simulator.device,
+                "serial_timeout": 0.5,
+                **FAST_TIMINGS,
+            },
+        )
+        simulator.drop_connections()
+        simulator.stop()
+        t0 = time.time()
+        with pytest.raises(Exception, match="Serial|serial"):
+            dome.slew_to_az(180.0)
+        # bounded: one transaction + the (shortened) reconnect cycle,
+        # nowhere near a request-timeout wedge
+        assert time.time() - t0 < 10

--- a/tests/chimera_lna/test_domelna.py
+++ b/tests/chimera_lna/test_domelna.py
@@ -6,6 +6,7 @@ Manager lifecycle, talking over a TCP socket to the dome controller simulator
 as if it were the real hardware.
 """
 
+import re
 import socket
 import time
 
@@ -48,10 +49,9 @@ class TestDomeSimulatorProtocol:
     def test_status_layout(self):
         with DomeSimulator(initial_tag=900) as simulator:
             response = raw_command(simulator, "MEADE PROG STATUS")
-            assert response.startswith("ACK")
+            assert re.fullmatch(r" {8}\d{3} \*[01]{16}", response)
             assert response[8:11] == "900"
             assert response[16] == "0"  # idle
-            assert len(response) >= 17
 
     def test_move_reports_busy_then_arrives(self):
         with DomeSimulator(initial_tag=900, tags_per_second=20) as simulator:
@@ -92,6 +92,38 @@ class TestDomeLNAUnits:
         # same as 801; 982 -> az 272, same as 802), so stop at 980
         for tag in (801, 820, 846, 900, 950, 980):
             assert DomeLNA._az_to_tag(DomeLNA._tag_to_az(tag)) == tag
+
+    def test_tag_distance_wraps(self):
+        assert DomeLNA._tag_distance(905, 905) == 0
+        assert DomeLNA._tag_distance(905, 907) == 2
+        # 981 overlaps 801: physically adjacent across the wrap
+        assert DomeLNA._tag_distance(802, 981) == 1
+        assert DomeLNA._tag_distance(801, 980) == 1
+        assert DomeLNA._tag_distance(805, 895) == 90
+
+    def test_status_frame_validation(self):
+        # clean frames, as captured from the real controller
+        m = DomeLNA._status_re.match("        900 *0010000000000000")
+        assert m and m.group(1) == "900" and m.group(2)[3] == "0"  # idle
+        m = DomeLNA._status_re.match("        805 *0001010000101000")
+        assert m and m.group(2)[3] == "1"  # busy
+        # EMI-corrupted frames captured on the wire must all be rejected
+        for frame in (
+            "    �   805 *0011010000101000",
+            "        979 *0015010010001000",
+            "        979 *0p11010010001000",
+            '    "   979 *0011010010001000',
+            "       $885 j0001010000101000",
+            "          0 *0001010000101000",
+            "        960 +0001010000101000",
+            "        960 ������j�",
+            "NAK",
+            "",
+        ):
+            assert DomeLNA._status_re.match(frame) is None, frame
+            assert DomeLNA._status_blank_re.match(frame) is None, frame
+        # blank tag (dome not initialized) is a distinct, valid case
+        assert DomeLNA._status_blank_re.match("            *0001010000101000")
 
 
 class TestDomeLNALifecycle:
@@ -161,4 +193,4 @@ class TestDomeLNALifecycle:
         manager.remove("/DomeLNA/stop")
         # after __stop__ the driver must have disconnected: the simulator
         # still answers new connections
-        assert raw_command(simulator, "MEADE PROG STATUS").startswith("ACK")
+        assert raw_command(simulator, "MEADE PROG STATUS")[8:11].isdigit()


### PR DESCRIPTION
Driver-side fixes for two live failures on the LNA 40 cm, stacked on #2 (base is `py3`; will retarget to `master` when #2 merges). Plan and full context in `docs/plans/dome-serial-io-thread.md`.

**The failures**

- 2026-07-22: a bus request and the dome control loop drove the serial port concurrently while `_reconnect()` swapped `self._serial` under a reader — `os.read(None, …)` `TypeError` propagated through `sync_with_tel()` and killed the running program.
- 2026-07-23: `slew_to_az` held the instance monitor for a whole slew with no timeout anywhere in the chain, so every later `@lock` call parked a bus pool worker forever; within an hour the whole chimera server bus was starved silent.

**The changes**

1. **Single-owner serial I/O thread.** One daemon thread owns the port: open, every command transaction, and reconnect. Callers submit commands through a queue and wait on a `Future` with a bounded deadline (one transaction + a full reconnect cycle), so a sick port surfaces as a clean exception instead of a wedged worker — and the reconnect-under-reader race is structurally impossible. The retry now also catches `OSError`/`TypeError`/`ValueError` (a half-open port fails inside pyserial in more ways than `SerialException` alone).
2. **Zero `@lock` in the driver.** The queue serializes port access; motion sequences (slew, slit, init) exclude each other through a private RLock acquired with a `motion_wait` timeout that raises "Dome busy" instead of blocking indefinitely. Status queries (`get_az`, `is_slewing`, `is_slit_open`, `is_sync_with_tel`) never wait on a slew: cache first, one queued STATUS at worst.
3. **`is_sync_with_tel()` override for the off-axis dome.** The LNA telescope is off the dome axis, so dome az ≠ telescope az by design (median 24° over the lookup table); the base on-axis check logged "Dome slit position could not be synchronized" on essentially every exposure (259× in one session) while the dome was correctly positioned. The override compares the current tag to the lookup-table tag for the telescope's alt/az, falling back to the base check when the telescope is unavailable or not tracking.

**Tests** (36 passing): simulator gained `drop_connections()` to sever live client connections; new concurrency tests cover status reads answering (< 2 s) while a slew is in flight, the bounded "Dome busy" error, transparent reconnect after a connection drop, a dead port raising within seconds instead of hanging, and the lookup-table sync check against a tracking `FakeTelescope`.

Companion core PR (independent, blast-radius only): astroufsc/chimera#261 — a raising `sync_with_tel()` degrades to a log line in `imagerequest`, and `DomeBase._process_queue()` no longer lets a failed slew kill the control loop.